### PR TITLE
Improvements towards conformity with XT standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # pcxtkbd
-PS/2 -> PC/XT Arduino based Keyboard adapter.
 
-Stable version.
-
+PS/2 -> PC/XT Arduino based Keyboard adapter originally by kesrut. 
+This version has IO changed to "open collector" to minimize the risk on shorting pins by mistake(frying the XT) and to conform with standard. Original version also had an issue that would cause an IBM XT to enter "Manufacturing mode" after POST so keyboard would only work 50% of the time in Cassette Basic. 
 
 Please add https://github.com/techpaul/PS2KeyAdvanced Arduino library to compile.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # pcxtkbd
 
 PS/2 -> PC/XT Arduino based Keyboard adapter originally by kesrut. 
-This version has IO changed to "open collector" to minimize the risk on shorting pins by mistake(frying the XT) and to conform with standard. Original version also had an issue that would cause an IBM XT to enter "Manufacturing mode" after POST so keyboard would only work 50% of the time in Cassette Basic. 
+This version has IO changed to "open collector" to minimize the risk on shorting pins by mistake(frying the XT) and to conform with standard. 
+
+Original version also had an issue that would cause an IBM XT to enter "Manufacturing mode" after POST so keyboard would only work 50% of the time in Cassette Basic. 
 
 Please add https://github.com/techpaul/PS2KeyAdvanced Arduino library to compile.
 


### PR DESCRIPTION
Hello Gentlemen,

As I was preparing to fork this nice project to work on adding a new feature, I noticed an existing fork that adds the following improvements:
 - IO changed to "open collector" to minimize the risk on shorting pins by mistake(frying the XT) and to conform with standard
 - Fixes issue that would cause an IBM XT to enter "Manufacturing mode" after POST so keyboard would only work 50% of the time in Cassette Basic
 
I just want to highlight about the possibility for these improvements to be pulled into the original repo.

Thank you for your work and contributions!